### PR TITLE
use msys2 to install and manage the mingw64 toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,33 @@
-FROM golang:1.18.1-windowsservercore-1809 as builder
+# escape=`
 
-# Install Chocolatey and use that to install the rest of the toolchain
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-RUN choco install -y cmake mingw --installargs 'ADD_CMAKE_TO_PATH=System'
+FROM mcr.microsoft.com/windows/servercore:1809 AS builder
+
+# Amend the path with tools we'll be installing in subsequent steps.
+RUN setx /M PATH "%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+
+# Install msys2 -- a lightweight, Linux-like environment, complete with its own
+# package manager.
+RUN curl `
+      -L `
+      https://github.com/msys2/msys2-installer/releases/download/2022-03-19/msys2-base-x86_64-20220319.sfx.exe `
+      -o C:\windows\temp\msys2-base.exe `
+    && C:\windows\temp\msys2-base.exe
+
+# Tell msys2's bash shell which toolchain we plan to work with. This will ensure
+# all details of the shell (path, for instance) are set up properly.
+ENV MSYSTEM=mingw64
+
+# Note the first time you use this bash shell, a lot of one-time initialization
+# occurs and you're advised to log out and back into the shell -- hence the
+# initial `bash -l -c true` before proceeding with what we care about.
+#
+# Install Go and the whole gcc/ld toolchain that can be used for compiling Go
+# programs that require CGO.
+RUN bash -l -c true `
+    && bash -l -c " `
+      pacman -S --noconfirm `
+        git `
+        mingw-w64-x86_64-cmake `
+        mingw-w64-x86_64-go `
+        mingw-w64-x86_64-toolchain `
+    "


### PR DESCRIPTION
This turns out to be a saner way to install the tools we need because msys2 comes with its own shell that is primed to work with all the tools available via its own package manager. In the end, it's like working with Linux, but on Windows. Think of it like WSL or Cygwin, except without the emulation layer. Targets still compile as native Windows executables. This has proven itself to be a better foundation for things Brigade needs to build for Windows.